### PR TITLE
ci: build and push docker image

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
     stage('Docker image'){
       environment {
         DOCKER_IMAGE = "observability-ci/package-registry"
-        DOCKER_TAG = "experimental"
+        DOCKER_TAG = "${env.BRANCH_NAME}"
         DOCKER_IMAGE_NAME = "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE}:${env.DOCKER_TAG}"
         DOCKER_IMAGE_NAME_SHA1 = "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE}:${env.GIT_BASE_COMMIT}"
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -6,6 +6,8 @@ pipeline {
   agent { label 'ubuntu && immutable' }
   environment {
     BASE_DIR="src/github.com/elastic/package-storage"
+    DOCKER_REGISTRY = 'docker.elastic.co'
+    DOCKER_REGISTRY_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     PIPELINE_LOG_LEVEL='INFO'
   }
   options {
@@ -46,19 +48,39 @@ pipeline {
         }
       }
     }
+    stage('Docker image'){
+      environment {
+        DOCKER_IMAGE = "observability-ci/package-registry"
+        DOCKER_TAG = "experimental"
+        DOCKER_IMAGE_NAME = "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE}:${env.DOCKER_TAG}"
+        DOCKER_IMAGE_NAME_SHA1 = "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE}:${env.GIT_BASE_COMMIT}"
+      }
+      when {
+        anyOf {
+          branch 'master'
+          branch "\\d+\\.\\d+"
+          branch "v\\d?"
+          tag "v\\d+\\.\\d+\\.\\d+*"
+        }
+      }
+      steps {
+        dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.DOCKER_REGISTRY}")
+        dir("${BASE_DIR}/dev"){
+          retry(3){
+            sh(label:'Build and push', script: """
+              docker buil -t ${env.DOCKER_IMAGE_NAME}
+              docker push ${env.DOCKER_IMAGE_NAME}
+              docker tag ${env.DOCKER_IMAGE_NAME} ${env.DOCKER_IMAGE_NAME_SHA1}
+              docker push ${env.DOCKER_IMAGE_NAME_SHA1}
+            """)
+          }
+        }
+      }
+    }
   }
   post {
-    success {
-      echoColor(text: '[SUCCESS]', colorfg: 'green', colorbg: 'default')
-    }
-    aborted {
-      echoColor(text: '[ABORTED]', colorfg: 'magenta', colorbg: 'default')
-    }
-    failure {
-      echoColor(text: '[FAILURE]', colorfg: 'red', colorbg: 'default')
-    }
-    unstable {
-      echoColor(text: '[UNSTABLE]', colorfg: 'yellow', colorbg: 'default')
+    cleanup {
+      notifyBuildResult(prComment: true)
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,6 +58,7 @@ pipeline {
       when {
         anyOf {
           branch 'master'
+          branch 'experimental'
           branch "\\d+\\.\\d+"
           branch "v\\d?"
           tag "v\\d+\\.\\d+\\.\\d+*"


### PR DESCRIPTION
build and push the Docker image to the observability-ci namespace. It also adds the comment with the build results on PRs and reporting build status to Elasticsearch.

related to https://github.com/elastic/package-storage/pull/9