### PR TITLE
Add dataset fields to all packages

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -8,9 +8,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/magefile/mage/sh"
 	"os"
 	"path/filepath"
+
+	"github.com/magefile/mage/sh"
 )
 
 var (

--- a/packages/aws/0.0.3/dataset/billing/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/billing/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/cloudtrail/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/cloudtrail/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/cloudwatch-logs/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/cloudwatch-logs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/cloudwatch-metrics/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/cloudwatch-metrics/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/dynamodb/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/dynamodb/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/ebs/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/ebs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/ec2-logs/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/ec2-logs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/ec2-metrics/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/ec2-metrics/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/elb-logs/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/elb-logs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/elb-metrics/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/elb-metrics/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/lambda/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/lambda/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/natgateway/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/natgateway/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/rds/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/rds/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/s3_daily_storage/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/s3_daily_storage/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/s3_request/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/s3_request/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/s3access/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/s3access/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/sns/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/sns/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/sqs/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/sqs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/transitgateway/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/transitgateway/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/usage/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/usage/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/vpcflow/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/vpcflow/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.0.3/dataset/vpn/fields/base-fields.yml
+++ b/packages/aws/0.0.3/dataset/vpn/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/billing/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/billing/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/cloudtrail/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/cloudtrail/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/cloudwatch-logs/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/cloudwatch-logs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/cloudwatch-metrics/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/cloudwatch-metrics/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/dynamodb/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/dynamodb/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/ebs/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/ebs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/ec2-logs/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/ec2-logs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/ec2-metrics/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/ec2-metrics/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/elb-logs/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/elb-logs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/elb-metrics/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/elb-metrics/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/lambda/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/lambda/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/natgateway/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/natgateway/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/rds/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/rds/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/s3_daily_storage/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/s3_daily_storage/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/s3_request/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/s3_request/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/s3access/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/s3access/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/sns/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/sns/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/sqs/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/sqs/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/transitgateway/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/transitgateway/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/usage/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/usage/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/vpcflow/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/vpcflow/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/aws/0.1.0/dataset/vpn/fields/base-fields.yml
+++ b/packages/aws/0.1.0/dataset/vpn/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/cisco/0.1.0/dataset/asa/fields/base-fields.yml
+++ b/packages/cisco/0.1.0/dataset/asa/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/cisco/0.1.0/dataset/ftd/fields/base-fields.yml
+++ b/packages/cisco/0.1.0/dataset/ftd/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/cisco/0.1.0/dataset/ios/fields/base-fields.yml
+++ b/packages/cisco/0.1.0/dataset/ios/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/cisco/0.1.1/dataset/asa/fields/base-fields.yml
+++ b/packages/cisco/0.1.1/dataset/asa/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/cisco/0.1.1/dataset/ftd/fields/base-fields.yml
+++ b/packages/cisco/0.1.1/dataset/ftd/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/cisco/0.1.1/dataset/ios/fields/base-fields.yml
+++ b/packages/cisco/0.1.1/dataset/ios/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/endpoint/0.1.0/dataset/events/fields/base-fields.yml
+++ b/packages/endpoint/0.1.0/dataset/events/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/endpoint/0.1.0/dataset/metadata/fields/base-fields.yml
+++ b/packages/endpoint/0.1.0/dataset/metadata/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/endpoint/0.2.0/dataset/events/fields/base-fields.yml
+++ b/packages/endpoint/0.2.0/dataset/events/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/endpoint/0.2.0/dataset/metadata/fields/base-fields.yml
+++ b/packages/endpoint/0.2.0/dataset/metadata/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/endpoint/0.2.0/dataset/policy/fields/base-fields.yml
+++ b/packages/endpoint/0.2.0/dataset/policy/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/endpoint/0.2.0/dataset/telemetry/fields/base-fields.yml
+++ b/packages/endpoint/0.2.0/dataset/telemetry/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/kafka/0.1.0/dataset/broker/fields/base-fields.yml
+++ b/packages/kafka/0.1.0/dataset/broker/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/kafka/0.1.0/dataset/consumergroup/fields/base-fields.yml
+++ b/packages/kafka/0.1.0/dataset/consumergroup/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/kafka/0.1.0/dataset/log/fields/base-fields.yml
+++ b/packages/kafka/0.1.0/dataset/log/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/kafka/0.1.0/dataset/partition/fields/base-fields.yml
+++ b/packages/kafka/0.1.0/dataset/partition/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/log/0.1.0/dataset/log/fields/base-fields.yml
+++ b/packages/log/0.1.0/dataset/log/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.0/dataset/error/fields/base-fields.yml
+++ b/packages/mysql/0.1.0/dataset/error/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.0/dataset/galera_status/fields/base-fields.yml
+++ b/packages/mysql/0.1.0/dataset/galera_status/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.0/dataset/slowlog/fields/base-fields.yml
+++ b/packages/mysql/0.1.0/dataset/slowlog/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.0/dataset/status/fields/base-fields.yml
+++ b/packages/mysql/0.1.0/dataset/status/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.1/dataset/error/fields/base-fields.yml
+++ b/packages/mysql/0.1.1/dataset/error/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.1/dataset/galera_status/fields/base-fields.yml
+++ b/packages/mysql/0.1.1/dataset/galera_status/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.1/dataset/slowlog/fields/base-fields.yml
+++ b/packages/mysql/0.1.1/dataset/slowlog/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.1/dataset/status/fields/base-fields.yml
+++ b/packages/mysql/0.1.1/dataset/status/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.2/dataset/error/fields/base-fields.yml
+++ b/packages/mysql/0.1.2/dataset/error/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.2/dataset/galera_status/fields/base-fields.yml
+++ b/packages/mysql/0.1.2/dataset/galera_status/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.2/dataset/slowlog/fields/base-fields.yml
+++ b/packages/mysql/0.1.2/dataset/slowlog/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/mysql/0.1.2/dataset/status/fields/base-fields.yml
+++ b/packages/mysql/0.1.2/dataset/status/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/netflow/0.1.0/dataset/log/fields/base-fields.yml
+++ b/packages/netflow/0.1.0/dataset/log/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.0/dataset/access/fields/base-fields.yml
+++ b/packages/nginx/0.1.0/dataset/access/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.0/dataset/error/fields/base-fields.yml
+++ b/packages/nginx/0.1.0/dataset/error/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.0/dataset/ingress_controller/fields/base-fields.yml
+++ b/packages/nginx/0.1.0/dataset/ingress_controller/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.0/dataset/stubstatus/fields/base-fields.yml
+++ b/packages/nginx/0.1.0/dataset/stubstatus/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.1/dataset/access/fields/base-fields.yml
+++ b/packages/nginx/0.1.1/dataset/access/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.1/dataset/error/fields/base-fields.yml
+++ b/packages/nginx/0.1.1/dataset/error/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.1/dataset/ingress_controller/fields/base-fields.yml
+++ b/packages/nginx/0.1.1/dataset/ingress_controller/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.1/dataset/stubstatus/fields/base-fields.yml
+++ b/packages/nginx/0.1.1/dataset/stubstatus/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.2/dataset/access/fields/base-fields.yml
+++ b/packages/nginx/0.1.2/dataset/access/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.2/dataset/error/fields/base-fields.yml
+++ b/packages/nginx/0.1.2/dataset/error/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.2/dataset/ingress_controller/fields/base-fields.yml
+++ b/packages/nginx/0.1.2/dataset/ingress_controller/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/nginx/0.1.2/dataset/stubstatus/fields/base-fields.yml
+++ b/packages/nginx/0.1.2/dataset/stubstatus/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.0/dataset/info/fields/base-fields.yml
+++ b/packages/redis/0.1.0/dataset/info/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.0/dataset/key/fields/base-fields.yml
+++ b/packages/redis/0.1.0/dataset/key/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.0/dataset/keyspace/fields/base-fields.yml
+++ b/packages/redis/0.1.0/dataset/keyspace/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.0/dataset/log/fields/base-fields.yml
+++ b/packages/redis/0.1.0/dataset/log/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.0/dataset/slowlog/fields/base-fields.yml
+++ b/packages/redis/0.1.0/dataset/slowlog/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.1/dataset/info/fields/base-fields.yml
+++ b/packages/redis/0.1.1/dataset/info/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.1/dataset/key/fields/base-fields.yml
+++ b/packages/redis/0.1.1/dataset/key/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.1/dataset/keyspace/fields/base-fields.yml
+++ b/packages/redis/0.1.1/dataset/keyspace/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.1/dataset/log/fields/base-fields.yml
+++ b/packages/redis/0.1.1/dataset/log/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.1/dataset/slowlog/fields/base-fields.yml
+++ b/packages/redis/0.1.1/dataset/slowlog/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.2/dataset/info/fields/base-fields.yml
+++ b/packages/redis/0.1.2/dataset/info/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.2/dataset/key/fields/base-fields.yml
+++ b/packages/redis/0.1.2/dataset/key/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.2/dataset/keyspace/fields/base-fields.yml
+++ b/packages/redis/0.1.2/dataset/keyspace/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.2/dataset/log/fields/base-fields.yml
+++ b/packages/redis/0.1.2/dataset/log/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/redis/0.1.2/dataset/slowlog/fields/base-fields.yml
+++ b/packages/redis/0.1.2/dataset/slowlog/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/auth/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/auth/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/core/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/core/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/cpu/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/cpu/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/diskio/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/diskio/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/entropy/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/entropy/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/filesystem/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/filesystem/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/fsstat/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/fsstat/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/load/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/load/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/memory/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/memory/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/network/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/network/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/network_summary/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/network_summary/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/process/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/process/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/process_summary/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/process_summary/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/raid/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/raid/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/service/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/service/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/socket/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/socket/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/socket_summary/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/socket_summary/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/syslog/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/syslog/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/uptime/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/uptime/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.

--- a/packages/system/0.1.0/dataset/users/fields/base-fields.yml
+++ b/packages/system/0.1.0/dataset/users/fields/base-fields.yml
@@ -14,3 +14,20 @@
   type: date
   description: >
     Event timestamp.
+
+- name: dataset.type
+  type: constant_keyword
+  description: >
+    Dataset type.
+- name: dataset.name
+  type: constant_keyword
+  description: >
+    Dataset name.
+- name: dataset.namespace
+  type: constant_keyword
+  description: >
+    Dataset namespace.
+- name: "@timestamp"
+  type: date
+  description: >
+    Event timestamp.


### PR DESCRIPTION
This is part of https://github.com/elastic/package-registry/issues/491 This PR adds the new dataset fields to each package. As soon as all PRs in the registry, Kibana and Agent are merged, the old stream fields can be removed.