### PR TITLE
Add testing environment to experimental branch

### DIFF
--- a/testing/environments/README.md
+++ b/testing/environments/README.md
@@ -1,0 +1,14 @@
+Before using the Package Registry, remember to `mage build` the project to prepare the volume with packages
+(`public` directory).
+
+Refresh docker images:
+
+```bash
+$ docker-compose -f snapshot.yml pull
+```
+
+Run docker containers (Elasticsearch, Kibana, Package Registry):
+
+```bash
+$ docker-compose -f snapshot.yml -f local.yml up --force-recreate
+```

--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -1,0 +1,15 @@
+server.name: kibana
+server.host: "0"
+
+elasticsearch.hosts: [ "http://elasticsearch:9200" ]
+elasticsearch.username: elastic
+elasticsearch.password: changeme
+xpack.monitoring.ui.container.elasticsearch.enabled: true
+
+xpack.ingestManager.enabled: true
+xpack.ingestManager.epm.enabled: true
+xpack.ingestManager.epm.registryUrl: "http://package-registry:8080"
+xpack.ingestManager.fleet.enabled: true
+xpack.ingestManager.fleet.elasticsearch.host: "http://elasticsearch:9200"
+xpack.ingestManager.fleet.kibana.host: "http://kibana:5601"
+xpack.ingestManager.fleet.tlsCheckDisabled: true

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -1,0 +1,20 @@
+# Defines if ports should be exported.
+# This is useful for testing locally with a full elastic stack setup.
+# All services can be reached through localhost like localhost:5601 for Kibana
+# This is not used for CI as otherwise ports conflicts could happen.
+version: '2.3'
+services:
+  kibana:
+    ports:
+      - "127.0.0.1:5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+
+  elasticsearch:
+    ports:
+      - "127.0.0.1:9200:9200"
+
+  package-registry:
+    ports:
+      - "127.0.0.1:8080:8080"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -1,0 +1,43 @@
+# This should start the environment with the latest snapshots.
+
+version: '2.3'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0-SNAPSHOT
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
+      retries: 300
+      interval: 1s
+    environment:
+    - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    - "network.host="
+    - "transport.host=127.0.0.1"
+    - "http.host=0.0.0.0"
+    - "indices.id_field_data.enabled=true"
+    - "xpack.license.self_generated.type=trial"
+    - "xpack.security.enabled=true"
+    - "xpack.security.authc.api_key.enabled=true"
+    - "ELASTIC_PASSWORD=changeme"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.8.0-SNAPSHOT
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      package-registry:
+        condition: service_healthy
+    healthcheck:
+      test: "curl -f http://localhost:5601/login | grep kbn-injected-metadata 2>&1 >/dev/null"
+      retries: 600
+      interval: 1s
+    volumes:
+      - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
+
+  package-registry:
+    image: docker.elastic.co/package-registry/package-registry:experimental
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      retries: 300
+      interval: 1s
+    volumes:
+      - ../../build/public:/registry/public


### PR DESCRIPTION
Based on https://github.com/elastic/package-storage/pull/78 I thought it is worth having the testing environment also available in the experimental branch to make testing for others easier.