### PR TITLE
Remove empty package-fields.yml from aws package

### DIFF
--- a/packages/aws/0.1.0/dataset/cloudtrail/fields/package-fields.yml
+++ b/packages/aws/0.1.0/dataset/cloudtrail/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: aws
-  type: group

--- a/packages/aws/0.1.0/dataset/cloudwatch-logs/fields/package-fields.yml
+++ b/packages/aws/0.1.0/dataset/cloudwatch-logs/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: aws
-  type: group

--- a/packages/aws/0.1.0/dataset/ec2-logs/fields/package-fields.yml
+++ b/packages/aws/0.1.0/dataset/ec2-logs/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: aws
-  type: group

--- a/packages/aws/0.1.0/dataset/elb-logs/fields/package-fields.yml
+++ b/packages/aws/0.1.0/dataset/elb-logs/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: aws
-  type: group

--- a/packages/aws/0.1.0/dataset/s3access/fields/package-fields.yml
+++ b/packages/aws/0.1.0/dataset/s3access/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: aws
-  type: group

--- a/packages/aws/0.1.0/dataset/vpcflow/fields/package-fields.yml
+++ b/packages/aws/0.1.0/dataset/vpcflow/fields/package-fields.yml
@@ -1,2 +1,0 @@
-- name: aws
-  type: group


### PR DESCRIPTION
With removing the empty package-fields.yml files, Kibana Discover is able to display json fields correctly:
<img width="1016" alt="Screen Shot 2020-06-17 at 3 32 26 PM" src="https://user-images.githubusercontent.com/14081635/84952782-ca6b0c80-b0af-11ea-957b-986407e729d9.png">
