### PR TITLE
feat: Build docker image

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -90,6 +90,38 @@ pipeline {
         }
       }
     }
+    /**
+     Publish Docker images.
+     */
+    stage('Publish Docker image'){
+      when {
+        not { changeRequest() }
+      }
+      environment {
+        DOCKER_IMG_TAG = "${env.DOCKER_IMG}:${env.GIT_BASE_COMMIT}"
+        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG}:${env.BRANCH_NAME}"
+      }
+      steps {
+        cleanup()
+        pushDockerImage()
+      }
+    }
+    /**
+     Publish PR Docker images.
+     */
+    stage('Publish PR Docker image'){
+      when {
+        changeRequest()
+      }
+      environment {
+        DOCKER_IMG_TAG = "${env.DOCKER_IMG_PR}:${env.GIT_BASE_COMMIT}"
+        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG_PR}:${env.BRANCH_NAME}"
+      }
+      steps {
+        cleanup()
+        pushDockerImage()
+      }
+    }
   }
   post {
     cleanup {
@@ -103,4 +135,29 @@ def cleanup(){
     deleteDir()
   }
   unstash 'source'
+}
+
+
+def pushDockerImage(){
+  dir("${BASE_DIR}"){
+    dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}",
+      registry: "${env.DOCKER_REGISTRY}")
+    sh(label: 'Build Docker image',
+      script: """docker build \
+        -t ${env.DOCKER_IMG_TAG} \
+        --label BRANCH_NAME=${env.BRANCH_NAME} \
+        --label GIT_SHA=${env.GIT_BASE_COMMIT} \
+        --label GO_VERSION=${env.GO_VERSION} \
+        --label TIMESTAMP=\$(date +%Y-%m-%d_%H:%M) \
+        .
+    """)
+    retryWithSleep(retries: 3, seconds: 5, backoff: true){
+      sh(label: 'Push Docker image sha',
+        script: "docker push ${env.DOCKER_IMG_TAG}")
+      sh(label: 'Re-tag Docker image',
+        script: "docker tag ${env.DOCKER_IMG_TAG} ${env.DOCKER_IMG_TAG_BRANCH}")
+      sh(label: 'Push Docker image name',
+        script: "docker push ${env.DOCKER_IMG_TAG_BRANCH}")
+    }
+  }
 }


### PR DESCRIPTION
add two new stages to build the Docker images for branches (docker.elastic.co/package-registry/distribution:BRANCH_NAME) and for PRs (docker.elastic.co/observability-ci/package-registry/distribution:PR-XXX)

**NOTE** we need to backport it to all branches.

related to https://github.com/elastic/package-storage/pull/88