### PR TITLE
Remove logs/metrics categories

### DIFF
--- a/packages/aws/0.0.3/manifest.yml
+++ b/packages/aws/0.0.3/manifest.yml
@@ -5,9 +5,6 @@ version: 0.0.3
 license: basic
 description: AWS Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/aws/0.1.0/manifest.yml
+++ b/packages/aws/0.1.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: AWS Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/aws/0.1.1/manifest.yml
+++ b/packages/aws/0.1.1/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.1
 license: basic
 description: AWS Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/base/0.1.0/manifest.yml
+++ b/packages/base/0.1.0/manifest.yml
@@ -7,7 +7,6 @@ description: >
 
   It contains the default ILM policies.
 version: 0.1.0
-categories: []
 release: ga
 
 # The base package cannot be removed

--- a/packages/base/0.2.0/manifest.yml
+++ b/packages/base/0.2.0/manifest.yml
@@ -7,7 +7,6 @@ description: >
 
   It contains the default ILM policies.
 version: 0.2.0
-categories: []
 release: ga
 
 # The base package cannot be removed

--- a/packages/base/0.3.0/manifest.yml
+++ b/packages/base/0.3.0/manifest.yml
@@ -7,7 +7,6 @@ description: >
 
   It contains the default ILM policies.
 version: 0.3.0
-categories: []
 release: ga
 
 # The base package cannot be removed

--- a/packages/cisco/0.1.0/manifest.yml
+++ b/packages/cisco/0.1.0/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.0
 license: basic
 description: Cisco Integration
 type: integration
-categories:
-  - logs
 release: beta
 removable: true
 requirement:

--- a/packages/cisco/0.1.1/manifest.yml
+++ b/packages/cisco/0.1.1/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.1
 license: basic
 description: Cisco Integration
 type: integration
-categories:
-  - logs
 release: beta
 removable: true
 requirement:

--- a/packages/cisco/0.1.2/manifest.yml
+++ b/packages/cisco/0.1.2/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.2
 license: basic
 description: Cisco Integration
 type: integration
-categories:
-  - logs
 release: beta
 removable: true
 requirement:

--- a/packages/kafka/0.1.0/manifest.yml
+++ b/packages/kafka/0.1.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: Kafka Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/kafka/0.1.1/manifest.yml
+++ b/packages/kafka/0.1.1/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.1
 license: basic
 description: Kafka Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/log/0.1.0/manifest.yml
+++ b/packages/log/0.1.0/manifest.yml
@@ -5,7 +5,6 @@ title: Customs logs
 description: >
   Collect your custom logs.
 version: 0.1.0
-categories: ["logs"]
 release: ga
 license: basic
 

--- a/packages/mysql/0.1.0/manifest.yml
+++ b/packages/mysql/0.1.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: MySQL Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/mysql/0.1.1/manifest.yml
+++ b/packages/mysql/0.1.1/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.1
 license: basic
 description: MySQL Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/mysql/0.1.2/manifest.yml
+++ b/packages/mysql/0.1.2/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.2
 license: basic
 description: MySQL Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/mysql/0.1.3/manifest.yml
+++ b/packages/mysql/0.1.3/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.3
 license: basic
 description: MySQL Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/netflow/0.1.0/manifest.yml
+++ b/packages/netflow/0.1.0/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.0
 license: basic
 description: NetFlow Integration
 type: integration
-categories:
-- logs
 release: beta
 removable: true
 requirement:

--- a/packages/netflow/0.1.1/manifest.yml
+++ b/packages/netflow/0.1.1/manifest.yml
@@ -5,8 +5,6 @@ version: 0.1.1
 license: basic
 description: NetFlow Integration
 type: integration
-categories:
-- logs
 release: beta
 removable: true
 requirement:

--- a/packages/nginx/0.1.0/manifest.yml
+++ b/packages/nginx/0.1.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: Nginx Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/nginx/0.1.1/manifest.yml
+++ b/packages/nginx/0.1.1/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.1
 license: basic
 description: Nginx Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/nginx/0.1.2/manifest.yml
+++ b/packages/nginx/0.1.2/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.2
 license: basic
 description: Nginx Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/nginx/0.1.3/manifest.yml
+++ b/packages/nginx/0.1.3/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.3
 license: basic
 description: Nginx Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/redis/0.1.0/manifest.yml
+++ b/packages/redis/0.1.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: Redis Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/redis/0.1.1/manifest.yml
+++ b/packages/redis/0.1.1/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.1
 license: basic
 description: Redis Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/redis/0.1.2/manifest.yml
+++ b/packages/redis/0.1.2/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.2
 license: basic
 description: Redis Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/redis/0.1.3/manifest.yml
+++ b/packages/redis/0.1.3/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.3
 license: basic
 description: Redis Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: true
 requirement:

--- a/packages/system/0.1.0/manifest.yml
+++ b/packages/system/0.1.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.1.0
 license: basic
 description: System Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: false
 screenshots:

--- a/packages/system/0.2.0/manifest.yml
+++ b/packages/system/0.2.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.2.0
 license: basic
 description: System Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: false
 screenshots:

--- a/packages/system/0.3.0/manifest.yml
+++ b/packages/system/0.3.0/manifest.yml
@@ -5,9 +5,6 @@ version: 0.3.0
 license: basic
 description: System Integration
 type: integration
-categories:
-- logs
-- metrics
 release: beta
 removable: false
 screenshots:


### PR DESCRIPTION
The logs and metrics categories do not exist anymore. In https://github.com/elastic/package-registry/pull/534 the supported categories were updated.

The categories are removed for now to allow the registry to remove the legacy support for these categories. The new releases of these packages must contain the new categories.