### PR TITLE
Update docker dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
 # Here the version of the registry is specified this storage branch uses.
 # It should always be a specific version to make sure builds are reproducible.
-ARG PACKAGE_REGISTRY=41c150c8020efc53ab16e3bba774c62a419b51ea
+ARG PACKAGE_REGISTRY=0579a6edb887c957c0fa64fc8ae82ca3f205a63b
 FROM docker.elastic.co/package-registry/package-registry:${PACKAGE_REGISTRY}
 
 LABEL package-registry=${PACKAGE_REGISTRY}
 
 # Adds specific config and packages
-COPY deployment/package-registry.yml /registry/config.yml
+COPY deployment/package-registry.yml /package-registry/config.yml
 COPY packages /packages/production
-
-# Cleanup
-RUN rm -r packages
 
 # Sanity check on the packages. If packages are not valid, container does not even build.
 RUN ./package-registry -dry-run

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/package-storage
 go 1.12
 
 require (
-	github.com/elastic/package-registry v0.4.1-0.20200702132954-41c150c8020e
+	github.com/elastic/package-registry v0.4.1-0.20200703075636-0579a6edb887
 	github.com/magefile/mage v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/elastic/package-registry v0.4.1-0.20200618213757-98d7184cfe5b h1:NKaN
 github.com/elastic/package-registry v0.4.1-0.20200618213757-98d7184cfe5b/go.mod h1:oQx3Tg9ynuC6APd0o0OHud9kyPX6S6IzdJp/R4Hj1HY=
 github.com/elastic/package-registry v0.4.1-0.20200702132954-41c150c8020e h1:B0i7PeWOSzKCX+Xba1SSTq7jAJKZK1IMwGfMOTOO/5I=
 github.com/elastic/package-registry v0.4.1-0.20200702132954-41c150c8020e/go.mod h1:ERTTIxAsQOCVZJDqR4LJbDDAtxV+pz4wdPPrKheiAUc=
+github.com/elastic/package-registry v0.4.1-0.20200703075636-0579a6edb887 h1:Wf8Xva3zsDKVgHcy9pPsUr7nEccFnyFjpO/P/Dom+hk=
+github.com/elastic/package-registry v0.4.1-0.20200703075636-0579a6edb887/go.mod h1:ERTTIxAsQOCVZJDqR4LJbDDAtxV+pz4wdPPrKheiAUc=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=

--- a/vendor/github.com/elastic/package-registry/util/package.go
+++ b/vendor/github.com/elastic/package-registry/util/package.go
@@ -75,16 +75,15 @@ type Package struct {
 
 // BasePackage is used for the output of the package info in the /search endpoint
 type BasePackage struct {
-	Name        string     `config:"name" json:"name"`
-	Title       *string    `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
-	Version     string     `config:"version" json:"version"`
-	Description string     `config:"description" json:"description"`
-	Type        string     `config:"type" json:"type"`
-	Download    string     `json:"download" yaml:"download,omitempty"`
-	Downloads   []Download `config:"downloads,omitempty" json:"downloads,omitempty" yaml:"downloads,omitempty"`
-	Path        string     `json:"path" yaml:"path,omitempty"`
-	Icons       []Image    `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
-	Internal    bool       `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
+	Name        string  `config:"name" json:"name"`
+	Title       *string `config:"title,omitempty" json:"title,omitempty" yaml:"title,omitempty"`
+	Version     string  `config:"version" json:"version"`
+	Description string  `config:"description" json:"description"`
+	Type        string  `config:"type" json:"type"`
+	Download    string  `json:"download" yaml:"download,omitempty"`
+	Path        string  `json:"path" yaml:"path,omitempty"`
+	Icons       []Image `config:"icons,omitempty" json:"icons,omitempty" yaml:"icons,omitempty"`
+	Internal    bool    `config:"internal,omitempty" json:"internal,omitempty" yaml:"internal,omitempty"`
 }
 
 type ConfigTemplate struct {
@@ -182,8 +181,6 @@ func NewPackage(basePath string) (*Package, error) {
 	}
 
 	p.Requirement = map[string]interface{}{}
-
-	p.Downloads = []Download{NewDownload(*p, "tar")}
 
 	if p.Conditions != nil && p.Conditions.KibanaVersion != "" {
 		p.Conditions.kibanaConstraint, err = semver.NewConstraint(p.Conditions.KibanaVersion)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/davecgh/go-spew/spew
 github.com/elastic/go-ucfg
 github.com/elastic/go-ucfg/parse
 github.com/elastic/go-ucfg/yaml
-# github.com/elastic/package-registry v0.4.1-0.20200702132954-41c150c8020e
+# github.com/elastic/package-registry v0.4.1-0.20200703075636-0579a6edb887
 github.com/elastic/package-registry/util
 # github.com/magefile/mage v1.9.0
 github.com/magefile/mage/mg


### PR DESCRIPTION
In https://github.com/elastic/package-registry/pull/583 the package-registry was updated to not contain any packages anymore and the Dockerfile path for the config was adjusted. This updates the production registry accordingly.