### PR TITLE
Update packages to use input: logfile instead of logs

### DIFF
--- a/packages/cisco/0.1.0/dataset/asa/manifest.yml
+++ b/packages/cisco/0.1.0/dataset/asa/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco ASA logs
   description: Collect Cisco ASA logs from file
   vars:

--- a/packages/cisco/0.1.0/dataset/ftd/manifest.yml
+++ b/packages/cisco/0.1.0/dataset/ftd/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco FTD logs
   description: Collect Cisco FTD logs from file
   vars:

--- a/packages/cisco/0.1.0/dataset/ios/manifest.yml
+++ b/packages/cisco/0.1.0/dataset/ios/manifest.yml
@@ -37,7 +37,7 @@ streams:
     required: true
     show_user: true
     default: 9002
-- input: logs
+- input: logfile
   title: Cisco IOS logs
   description: Collect Cisco IOS logs from file
   vars:

--- a/packages/cisco/0.1.0/manifest.yml
+++ b/packages/cisco/0.1.0/manifest.yml
@@ -33,6 +33,6 @@ config_templates:
       - type: syslog
         title: Collect logs from Cisco via syslog
         description: Collecting logs from Cisco IOS via syslog
-      - type: logs
+      - type: logfile
         title: Collect logs from Cisco via file
         description: Collecting logs from Cisco ASA, FTD, and IOS via file

--- a/packages/cisco/0.1.1/dataset/asa/manifest.yml
+++ b/packages/cisco/0.1.1/dataset/asa/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco ASA logs
   description: Collect Cisco ASA logs from file
   vars:

--- a/packages/cisco/0.1.1/dataset/ftd/manifest.yml
+++ b/packages/cisco/0.1.1/dataset/ftd/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco FTD logs
   description: Collect Cisco FTD logs from file
   vars:

--- a/packages/cisco/0.1.1/dataset/ios/manifest.yml
+++ b/packages/cisco/0.1.1/dataset/ios/manifest.yml
@@ -37,7 +37,7 @@ streams:
     required: true
     show_user: true
     default: 9002
-- input: logs
+- input: logfile
   title: Cisco IOS logs
   description: Collect Cisco IOS logs from file
   vars:

--- a/packages/cisco/0.1.1/manifest.yml
+++ b/packages/cisco/0.1.1/manifest.yml
@@ -33,6 +33,6 @@ config_templates:
       - type: syslog
         title: Collect logs from Cisco via syslog
         description: Collecting logs from Cisco IOS via syslog
-      - type: logs
+      - type: logfile
         title: Collect logs from Cisco via file
         description: Collecting logs from Cisco ASA, FTD, and IOS via file

--- a/packages/cisco/0.1.2/dataset/asa/manifest.yml
+++ b/packages/cisco/0.1.2/dataset/asa/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco ASA logs
   description: Collect Cisco ASA logs from file
   vars:

--- a/packages/cisco/0.1.2/dataset/ftd/manifest.yml
+++ b/packages/cisco/0.1.2/dataset/ftd/manifest.yml
@@ -36,7 +36,7 @@ streams:
     required: true
     show_user: false
     default: 7
-- input: logs
+- input: logfile
   title: Cisco FTD logs
   description: Collect Cisco FTD logs from file
   vars:

--- a/packages/cisco/0.1.2/dataset/ios/manifest.yml
+++ b/packages/cisco/0.1.2/dataset/ios/manifest.yml
@@ -37,7 +37,7 @@ streams:
     required: true
     show_user: true
     default: 9002
-- input: logs
+- input: logfile
   title: Cisco IOS logs
   description: Collect Cisco IOS logs from file
   vars:

--- a/packages/cisco/0.1.2/manifest.yml
+++ b/packages/cisco/0.1.2/manifest.yml
@@ -33,6 +33,6 @@ config_templates:
       - type: syslog
         title: Collect logs from Cisco via syslog
         description: Collecting logs from Cisco IOS via syslog
-      - type: logs
+      - type: logfile
         title: Collect logs from Cisco via file
         description: Collecting logs from Cisco ASA, FTD, and IOS via file

--- a/packages/kafka/0.1.0/dataset/log/manifest.yml
+++ b/packages/kafka/0.1.0/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Kafka log logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: kafka_home
     type: text

--- a/packages/kafka/0.1.0/manifest.yml
+++ b/packages/kafka/0.1.0/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Kafka logs and metrics
   description: Collect logs and metrics from Kafka brokers
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Kafka brokers
     description: Collecting Kafka log logs
   - type: kafka/metrics

--- a/packages/kafka/0.1.1/dataset/log/manifest.yml
+++ b/packages/kafka/0.1.1/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Kafka log logs
 release: beta
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: kafka_home
     type: text

--- a/packages/kafka/0.1.1/manifest.yml
+++ b/packages/kafka/0.1.1/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Kafka logs and metrics
   description: Collect logs and metrics from Kafka brokers
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Kafka brokers
     description: Collecting Kafka log logs
   - type: kafka/metrics

--- a/packages/log/0.1.0/dataset/log/manifest.yml
+++ b/packages/log/0.1.0/dataset/log/manifest.yml
@@ -6,7 +6,7 @@ default: true
 id: generic
 
 streams:
-  - input: logs
+  - input: logfile
     title: Collect log files
     vars:
       - name: paths

--- a/packages/log/0.1.0/manifest.yml
+++ b/packages/log/0.1.0/manifest.yml
@@ -14,7 +14,7 @@ config_templates:
     title: Custom logs
     description: Collect your custom log files.
     inputs:
-      - type: logs
+      - type: logfile
         title: Custom log file
         description: Collect your custom log files.
 

--- a/packages/mysql/0.1.0/dataset/error/manifest.yml
+++ b/packages/mysql/0.1.0/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.0/dataset/slowlog/manifest.yml
+++ b/packages/mysql/0.1.0/dataset/slowlog/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL slowlog logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.0/manifest.yml
+++ b/packages/mysql/0.1.0/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: MySQL logs and metrics
   description: Collect logs and metrics from MySQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from MySQL hosts
     description: Collecting MySQL error and slowlog logs
   - type: mysql/metrics

--- a/packages/mysql/0.1.1/dataset/error/manifest.yml
+++ b/packages/mysql/0.1.1/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.1/dataset/slowlog/manifest.yml
+++ b/packages/mysql/0.1.1/dataset/slowlog/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL slowlog logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.1/manifest.yml
+++ b/packages/mysql/0.1.1/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: MySQL logs and metrics
   description: Collect logs and metrics from MySQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from MySQL hosts
     description: Collecting MySQL error and slowlog logs
   - type: mysql/metrics

--- a/packages/mysql/0.1.2/dataset/error/manifest.yml
+++ b/packages/mysql/0.1.2/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.2/dataset/slowlog/manifest.yml
+++ b/packages/mysql/0.1.2/dataset/slowlog/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL slowlog logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.2/manifest.yml
+++ b/packages/mysql/0.1.2/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: MySQL logs and metrics
   description: Collect logs and metrics from MySQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from MySQL hosts
     description: Collecting MySQL error and slowlog logs
   - type: mysql/metrics

--- a/packages/mysql/0.1.3/dataset/error/manifest.yml
+++ b/packages/mysql/0.1.3/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.3/dataset/slowlog/manifest.yml
+++ b/packages/mysql/0.1.3/dataset/slowlog/manifest.yml
@@ -2,7 +2,7 @@ title: MySQL slowlog logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/mysql/0.1.3/manifest.yml
+++ b/packages/mysql/0.1.3/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: MySQL logs and metrics
   description: Collect logs and metrics from MySQL instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from MySQL hosts
     description: Collecting MySQL error and slowlog logs
   - type: mysql/metrics

--- a/packages/nginx/0.1.0/dataset/access/manifest.yml
+++ b/packages/nginx/0.1.0/dataset/access/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx access logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.0/dataset/error/manifest.yml
+++ b/packages/nginx/0.1.0/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.0/dataset/ingress_controller/manifest.yml
+++ b/packages/nginx/0.1.0/dataset/ingress_controller/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx ingress_controller logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   enabled: false
   vars:
   - name: paths

--- a/packages/nginx/0.1.0/manifest.yml
+++ b/packages/nginx/0.1.0/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Nginx logs and metrics
   description: Collect logs and metrics from Nginx instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Nginx instances
     description: Collecting Nginx access, error and ingress controller logs
   - type: nginx/metrics

--- a/packages/nginx/0.1.1/dataset/access/manifest.yml
+++ b/packages/nginx/0.1.1/dataset/access/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx access logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.1/dataset/error/manifest.yml
+++ b/packages/nginx/0.1.1/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.1/dataset/ingress_controller/manifest.yml
+++ b/packages/nginx/0.1.1/dataset/ingress_controller/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx ingress_controller logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   enabled: false
   vars:
   - name: paths

--- a/packages/nginx/0.1.1/manifest.yml
+++ b/packages/nginx/0.1.1/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Nginx logs and metrics
   description: Collect logs and metrics from Nginx instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Nginx instances
     description: Collecting Nginx access, error and ingress controller logs
   - type: nginx/metrics

--- a/packages/nginx/0.1.2/dataset/access/manifest.yml
+++ b/packages/nginx/0.1.2/dataset/access/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx access logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.2/dataset/error/manifest.yml
+++ b/packages/nginx/0.1.2/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.2/dataset/ingress_controller/manifest.yml
+++ b/packages/nginx/0.1.2/dataset/ingress_controller/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx ingress_controller logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   enabled: false
   vars:
   - name: paths

--- a/packages/nginx/0.1.2/manifest.yml
+++ b/packages/nginx/0.1.2/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Nginx logs and metrics
   description: Collect logs and metrics from Nginx instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Nginx instances
     description: Collecting Nginx access, error and ingress controller logs
   - type: nginx/metrics

--- a/packages/nginx/0.1.3/dataset/access/manifest.yml
+++ b/packages/nginx/0.1.3/dataset/access/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx access logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.3/dataset/error/manifest.yml
+++ b/packages/nginx/0.1.3/dataset/error/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx error logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/nginx/0.1.3/dataset/ingress_controller/manifest.yml
+++ b/packages/nginx/0.1.3/dataset/ingress_controller/manifest.yml
@@ -2,7 +2,7 @@ title: Nginx ingress_controller logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   enabled: false
   vars:
   - name: paths

--- a/packages/nginx/0.1.3/manifest.yml
+++ b/packages/nginx/0.1.3/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Nginx logs and metrics
   description: Collect logs and metrics from Nginx instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from Nginx instances
     description: Collecting Nginx access, error and ingress controller logs
   - type: nginx/metrics

--- a/packages/redis/0.1.0/dataset/log/manifest.yml
+++ b/packages/redis/0.1.0/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Redis application logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/redis/0.1.0/manifest.yml
+++ b/packages/redis/0.1.0/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Redis logs and metrics
   description: Collect logs and metrics from Redis instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect Redis application logs
     description: Collecting application logs from Redis instances
   - type: redis

--- a/packages/redis/0.1.1/dataset/log/manifest.yml
+++ b/packages/redis/0.1.1/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Redis application logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/redis/0.1.1/manifest.yml
+++ b/packages/redis/0.1.1/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Redis logs and metrics
   description: Collect logs and metrics from Redis instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect Redis application logs
     description: Collecting application logs from Redis instances
   - type: redis

--- a/packages/redis/0.1.2/dataset/log/manifest.yml
+++ b/packages/redis/0.1.2/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Redis application logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/redis/0.1.2/manifest.yml
+++ b/packages/redis/0.1.2/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Redis logs and metrics
   description: Collect logs and metrics from Redis instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect Redis application logs
     description: Collecting application logs from Redis instances
   - type: redis

--- a/packages/redis/0.1.3/dataset/log/manifest.yml
+++ b/packages/redis/0.1.3/dataset/log/manifest.yml
@@ -2,7 +2,7 @@ title: Redis application logs
 type: logs
 release: beta
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/redis/0.1.3/manifest.yml
+++ b/packages/redis/0.1.3/manifest.yml
@@ -31,7 +31,7 @@ config_templates:
   title: Redis logs and metrics
   description: Collect logs and metrics from Redis instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect Redis application logs
     description: Collecting application logs from Redis instances
   - type: redis

--- a/packages/system/0.1.0/dataset/auth/manifest.yml
+++ b/packages/system/0.1.0/dataset/auth/manifest.yml
@@ -2,7 +2,7 @@ title: System auth logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/0.1.0/dataset/syslog/manifest.yml
+++ b/packages/system/0.1.0/dataset/syslog/manifest.yml
@@ -2,7 +2,7 @@ title: System syslog logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/0.1.0/manifest.yml
+++ b/packages/system/0.1.0/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: System logs and metrics
   description: Collect logs and metrics from System instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from System instances
     description: Collecting System auth and syslog logs
   - type: system/metrics

--- a/packages/system/0.2.0/dataset/auth/manifest.yml
+++ b/packages/system/0.2.0/dataset/auth/manifest.yml
@@ -2,7 +2,7 @@ title: System auth logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/0.2.0/dataset/syslog/manifest.yml
+++ b/packages/system/0.2.0/dataset/syslog/manifest.yml
@@ -2,7 +2,7 @@ title: System syslog logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/0.2.0/manifest.yml
+++ b/packages/system/0.2.0/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: System logs and metrics
   description: Collect logs and metrics from System instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from System instances
     description: Collecting System auth and syslog logs
   - type: system/metrics

--- a/packages/system/0.3.0/dataset/auth/manifest.yml
+++ b/packages/system/0.3.0/dataset/auth/manifest.yml
@@ -2,7 +2,7 @@ title: System auth logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/0.3.0/dataset/syslog/manifest.yml
+++ b/packages/system/0.3.0/dataset/syslog/manifest.yml
@@ -2,7 +2,7 @@ title: System syslog logs
 release: experimental
 type: logs
 streams:
-- input: logs
+- input: logfile
   vars:
   - name: paths
     type: text

--- a/packages/system/0.3.0/manifest.yml
+++ b/packages/system/0.3.0/manifest.yml
@@ -30,7 +30,7 @@ config_templates:
   title: System logs and metrics
   description: Collect logs and metrics from System instances
   inputs:
-  - type: logs
+  - type: logfile
     title: Collect logs from System instances
     description: Collecting System auth and syslog logs
   - type: system/metrics


### PR DESCRIPTION
The agent currently supports logfile and logs for the input type. This switches over all packages to use logfile so it can be removed in the agent. Integrations repository is already updated.