### PR TITLE
Adding Ruflin's table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ This is a storage repository for the packages served through the [package regist
 
 It contains 3 branches with the packages for the different environments:
 
-* production
-* staging
 * snapshot
+* staging
+* production
+
+Here's how these branches relate to repositories and other aspects of packages.
+
+|                       | Snapshot                    | Staging                    | Production                |
+|-------------------    |-------------------------    |------------------------    |-----------------------    |
+| URL                   | epr-snapshot.elastic.co     | epr-staging.elastic.co     | epr.elastic.co            |
+| Add package           | Commit                      | Commit                     | PR                        |
+| Version overwrite     | yes                         | if needed                  | no                        |
+| Stack Version         | *-SNAPSHOT                  | *-SNAPSHOT                 | Released (candidates)     |
+| Registry Version      | fixed version                | Stable release             | Stable release            |
+| Branch                | snapshot                    | staging                    | production                |
+| Packages              | snapshot+staging+prod       | staging+production         | production                |
+| Release               | Automated                   | Automated                  | Manual                 |
+| Docker image          | snapshot                    | staging                    | production                |


### PR DESCRIPTION
Add's the excellent table @ruflin made in https://github.com/elastic/package-storage/issues/86 to this repo's README so it's a bit more discoverable 🙂. 