### PR TITLE
ci: build after a successful build of production

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*()(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test$)')
+    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test$)')
     upstream("${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : 'Beats/package-storage/production' }")
   }
   parameters {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test$)')
+    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^\\/test$)')
     upstream("${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : 'Beats/package-storage/production' }")
   }
   parameters {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*()(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^/test$)')
+    upstream("${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : 'Beats/package-storage/production' }")
   }
   parameters {
     booleanParam(name: 'run_all_stages', defaultValue: false, description: 'Force to run all stages.')


### PR DESCRIPTION
This will generate a staging Docker image just after generating a production Docker image, this propagates the changes on cascade. also, adds the `/test` GitHub message as a build trigger

related to https://github.com/elastic/package-storage/issues/151