### PR TITLE
Remove 8.0.0 kibana version from registry request

### DIFF
--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -128,7 +128,7 @@ type Package struct {
 }
 
 func getPackages(t *testing.T) ([]string, error) {
-	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=8.0.0")
+	resp, err := http.Get("http://localhost:8080/search?experimental=true")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now that Kibana snapshot versions don't send a version string when making requests to the registry we should remove the `8.0.0` restraint in CI to determine which packages to install so that we can support `^7.9.0` in production.

See this also: https://github.com/elastic/package-storage/pull/179#issuecomment-666516946