### PR TITLE
[staging] Use Kibana 7.9.0-SNAPSHOT for testing

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ELASTIC_PASSWORD=changeme"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -128,7 +128,8 @@ type Package struct {
 }
 
 func getPackages(t *testing.T) ([]string, error) {
-	resp, err := http.Get("http://localhost:8080/search?experimental=true")
+	// The kibana.version must be in sync with the stack version used in snapshot.yml
+	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=7.9.0")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Based on https://github.com/elastic/package-storage/issues/163 switching over to use 7.9.0-SNAPSHOT for testing.