### PR TITLE
ci: build after a successful build of production (resubmit of #176)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*|^\\/test$)')
+    upstream("${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : 'Beats/package-storage/staging' }")
   }
   parameters {
     booleanParam(name: 'run_all_stages', defaultValue: false, description: 'Force to run all stages.')


### PR DESCRIPTION
This resubmits #176 onto the snapshot branch after a failed rebase.

Original description:

This will generate a snapshot Docker image just after generating a staging Docker image, this propagates the changes on cascade. also, adds the /test GitHub message as a build trigger

related to #151