### PR TITLE
[production] Removing dataset fields

### DIFF
--- a/packages/barracuda/0.1.0/dataset/waf/fields/base-fields.yml
+++ b/packages/barracuda/0.1.0/dataset/waf/fields/base-fields.yml
@@ -10,20 +10,3 @@
   type: constant_keyword
   description: >
     Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/bluecoat/0.1.0/dataset/director/fields/base-fields.yml
+++ b/packages/bluecoat/0.1.0/dataset/director/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/citrix/0.1.0/dataset/virtualapps/fields/base-fields.yml
+++ b/packages/citrix/0.1.0/dataset/virtualapps/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/cylance/0.1.0/dataset/protect/fields/base-fields.yml
+++ b/packages/cylance/0.1.0/dataset/protect/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/f5/0.1.0/dataset/bigipapm/fields/base-fields.yml
+++ b/packages/f5/0.1.0/dataset/bigipapm/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/imperva/0.1.0/dataset/securesphere/fields/base-fields.yml
+++ b/packages/imperva/0.1.0/dataset/securesphere/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/infoblox/0.1.0/dataset/nios/fields/base-fields.yml
+++ b/packages/infoblox/0.1.0/dataset/nios/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/juniper/0.1.0/dataset/junos/fields/base-fields.yml
+++ b/packages/juniper/0.1.0/dataset/junos/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/kaspersky/0.1.0/dataset/av/fields/base-fields.yml
+++ b/packages/kaspersky/0.1.0/dataset/av/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/netscout/0.1.0/dataset/sightline/fields/base-fields.yml
+++ b/packages/netscout/0.1.0/dataset/sightline/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/radware/0.1.0/dataset/defensepro/fields/base-fields.yml
+++ b/packages/radware/0.1.0/dataset/defensepro/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/rapid7/0.1.0/dataset/nexpose/fields/base-fields.yml
+++ b/packages/rapid7/0.1.0/dataset/nexpose/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/sonicwall/0.1.0/dataset/firewall/fields/base-fields.yml
+++ b/packages/sonicwall/0.1.0/dataset/firewall/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/squid/0.1.0/dataset/log/fields/base-fields.yml
+++ b/packages/squid/0.1.0/dataset/log/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/tenable/0.1.0/dataset/nessus_security/fields/base-fields.yml
+++ b/packages/tenable/0.1.0/dataset/nessus_security/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/tomcat/0.1.0/dataset/log/fields/base-fields.yml
+++ b/packages/tomcat/0.1.0/dataset/log/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.

--- a/packages/zscaler/0.1.0/dataset/zia/fields/base-fields.yml
+++ b/packages/zscaler/0.1.0/dataset/zia/fields/base-fields.yml
@@ -7,20 +7,3 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Datastream namespace.
-
-- name: dataset.type
-  type: constant_keyword
-  description: >
-    Dataset type.
-- name: dataset.name
-  type: constant_keyword
-  description: >
-    Dataset name.
-- name: dataset.namespace
-  type: constant_keyword
-  description: >
-    Dataset namespace.
-- name: "@timestamp"
-  type: date
-  description: >
-    Event timestamp.


### PR DESCRIPTION
This removes the `dataset.*` fields from packages that are not in the integration repo. This does not include endpoint. That'll come in a different PR.

Full disclosure I haven't really tested this 😬 