### PR TITLE
[staging] Add encryption key to Kibana config (#329)

### DIFF
--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -12,3 +12,5 @@ xpack.ingestManager.fleet.enabled: true
 xpack.ingestManager.fleet.elasticsearch.host: "http://elasticsearch:9200"
 xpack.ingestManager.fleet.kibana.host: "http://kibana:5601"
 xpack.ingestManager.fleet.tlsCheckDisabled: true
+
+xpack.encryptedSavedObjects.encryptionKey: "this-is-not-a-real-key-but-gets-the-job-done"


### PR DESCRIPTION
Having an encryption key in the Kibana config allows to spin up the environment and use Fleet. This is useful if a PR should be tested locally with an Agent.