### PR TITLE
[production] Improve integration testing script

### DIFF
--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -98,28 +98,31 @@ func TestSetup(t *testing.T) {
 			// Get a local copy
 			p := p
 			t.Run(p, func(t *testing.T) {
-				t.Parallel()
-				req, err = http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/ingest_manager/epm/packages/"+p, nil)
-				if err != nil {
-					t.Error(err)
-				}
-				req.Header.Add("kbn-xsrf", "ingest_manager")
-				resp, err = http.DefaultClient.Do(req)
-				if err != nil {
-					t.Error(err)
-				}
-				defer resp.Body.Close()
-
-				assert.Equal(t, 200, resp.StatusCode)
-
-				body, err = ioutil.ReadAll(resp.Body)
-				if err != nil {
-					t.Error(err)
-				}
-				log.Println(p)
+				installPackage(t, p)
 			})
 		}
 	})
+}
+
+func installPackage(t *testing.T, p string) {
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/ingest_manager/epm/packages/"+p, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	req.Header.Add("kbn-xsrf", "ingest_manager")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Error(err)
+	}
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error(err, string(body))
+	}
+	log.Println(p)
 }
 
 type Package struct {


### PR DESCRIPTION
This change improves the integration testing script by removing the parallel execution. On of the flaky parts around this script was, that sometimes Kibana was overloaded by the number of requests and returned a 429. The tests were run in parallel as initially installing a package was much slower then it is now. Even though this change means tests take between 60-120 seconds longer overall, I think the benefit of having less flaky tests are worth the change.

Long term, it would be great if the tests are only run on the packages that actually changed instead of all packages.

To clean up the code a bit, `installPackage` was moved into its own method.