### PR TITLE
[production] Increase cache time for assets

### DIFF
--- a/deployment/package-registry.yml
+++ b/deployment/package-registry.yml
@@ -1,6 +1,6 @@
 package_paths:
   - /packages/production
 
-cache_time.search: 10s
-cache_time.categories: 10s
-cache_time.catch_all: 10s
+cache_time.search: 1m
+cache_time.categories: 10m
+cache_time.catch_all: 10m


### PR DESCRIPTION
On production, we should use a higher cache time for assets. Especially the static assets should not change. The search API has only a cache time of 1min to show new packages quickly. The category endpoint is 10m as if the counter of a package is not immedititely correct it is not an issue.

Long term, we should increase these values further.