### PR TITLE
Add details around production-7.9 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The current `package-storage` repository has a few branches. This is a quick sum
 * production: Packages for epr.elastic.co
 * staging: Packages for epr-staging.elastic.co
 * snapshot: Packages for epr-snapshot.elastic.co
-* production-7.9: Packages for epr-7-9.elastic.co. These packages are served for Kibana 7.9 versions.
+* production-7.9: Packages for epr-7-9.elastic.co. These packages are served for Kibana 7.9 versions. It is expected that all future changes to packages go into the production branch.
 * experimental: Packages for epr-experimental.elastic.co. These packages are served for Kibana 7.8 and will disappear in the future. No updates should happen to this branch.
 * master: Contains docs and comment scripts for the distribution branches.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# EXPERIMENTAL: This is only for experimental use
-
 # Package Storage
 This is a storage repository for the packages served through the [package registry](https://github.com/elastic/package-registry) service.
 
@@ -84,7 +82,8 @@ The current `package-storage` repository has a few branches. This is a quick sum
 * production: Packages for epr.elastic.co
 * staging: Packages for epr-staging.elastic.co
 * snapshot: Packages for epr-snapshot.elastic.co
-* experimental: Packages for epr-experimental.elastic.co. These packages are served by Kibana 7.8 and will disappear in the future. No updates should happen to this branch.
+* production-7.9: Packages for epr-7-9.elastic.co. These packages are served for Kibana 7.9 versions.
+* experimental: Packages for epr-experimental.elastic.co. These packages are served for Kibana 7.8 and will disappear in the future. No updates should happen to this branch.
 * master: Contains docs and comment scripts for the distribution branches.
 
 # Tags


### PR DESCRIPTION
A new branch called `production-7.9` was added for our 7.9 registry which is used by Kibana 7.9. This adds details around it to the README.

In addition I removed the experimental README header as this is not so experimental anymore.