### PR TITLE
[snapshot] Update testing of snapshot to 7.10

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ELASTIC_PASSWORD=changeme"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.9.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -132,7 +132,7 @@ type Package struct {
 
 func getPackages(t *testing.T) ([]string, error) {
 	// The kibana.version must be in sync with the stack version used in snapshot.yml
-	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=7.9.0")
+	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=7.10.0")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
All currently developed packages are only expected to be compatible with 7.10 and upwards. Because of this the testing version is incremented to 7.10