### PR TITLE
[production] Use EPR in version 0.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Here the version of the registry is specified this storage branch uses.
 # It should always be a specific version to make sure builds are reproducible.
-ARG PACKAGE_REGISTRY=v0.12.0
+ARG PACKAGE_REGISTRY=v0.12.1
 FROM docker.elastic.co/package-registry/package-registry:${PACKAGE_REGISTRY}
 
 LABEL package-registry=${PACKAGE_REGISTRY}


### PR DESCRIPTION
This PR updates the package-storage distribution to use EPR 0.12.1.