### PR TITLE
[staging] Use EPR in version 0.12.1 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 
 FROM docker.elastic.co/package-registry/distribution:production AS production
 
-FROM docker.elastic.co/package-registry/package-registry:v0.12.0
-LABEL package-registry=v0.12.0
+FROM docker.elastic.co/package-registry/package-registry:v0.12.1
+LABEL package-registry=v0.12.1
 
 COPY --from=production /packages/production /packages/production
 


### PR DESCRIPTION
This PR updates the package-storage distribution to use EPR 0.12.1.