### PR TITLE
[snapshot] Rename ingest_manager to fleet

### DIFF
--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -6,11 +6,11 @@ elasticsearch.username: elastic
 elasticsearch.password: changeme
 xpack.monitoring.ui.container.elasticsearch.enabled: true
 
-xpack.ingestManager.enabled: true
-xpack.ingestManager.registryUrl: "http://package-registry:8080"
-xpack.ingestManager.fleet.enabled: true
-xpack.ingestManager.fleet.elasticsearch.host: "http://elasticsearch:9200"
-xpack.ingestManager.fleet.kibana.host: "http://kibana:5601"
-xpack.ingestManager.fleet.tlsCheckDisabled: true
+xpack.fleet.enabled: true
+xpack.fleet.registryUrl: "http://package-registry:8080"
+xpack.fleet.agents.enabled: true
+xpack.fleet.agents.elasticsearch.host: "http://elasticsearch:9200"
+xpack.fleet.agents.kibana.host: "http://kibana:5601"
+xpack.fleet.agents.tlsCheckDisabled: true
 
 xpack.encryptedSavedObjects.encryptionKey: "this-is-not-a-real-key-but-gets-the-job-done"

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -67,8 +67,8 @@ func TestSetup(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	}
 
-	// Run setup in ingest_manager against registry to see if no errors are returned
-	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/ingest_manager/setup", nil)
+	// Run setup in fleet against registry to see if no errors are returned
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/fleet/setup", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -105,7 +105,7 @@ func TestSetup(t *testing.T) {
 }
 
 func installPackage(t *testing.T, p string) {
-	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/ingest_manager/epm/packages/"+p, nil)
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/fleet/epm/packages/"+p, nil)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This PR renames `ingest_manager` to `fleet` due to latest breaking changes pushed to Kibana.

Spotted in: https://github.com/elastic/package-storage/pull/457