### PR TITLE
[snapshot] Increase ES cache size and template compilation limit (#511)

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -18,6 +18,10 @@ services:
     - "xpack.security.enabled=true"
     - "xpack.security.authc.api_key.enabled=true"
     - "ELASTIC_PASSWORD=changeme"
+    - "script.context.template.max_compilations_rate=unlimited"
+    - "script.context.ingest.cache_max_size=2000"
+    - "script.context.processor_conditional.cache_max_size=2000"
+    - "script.context.template.cache_max_size=2000"
 
   kibana:
     image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT


### PR DESCRIPTION
This increases the compilation rate limit on templates in scripts (e.g. `{{foo.bar}}`). The other contexts
relevant to ingest pipelines are `ingest` and `pipeline_conditional`. Those two do not need changes
because they are unlimited by default.

And it increases the cache size for the ingest, processor_conditional, and template script caches.
Since the test installs every possible pipeline ES reaches the cache limit which causes evictions.

After making these changes there are no cache evictions or rate limits.

```
GET _nodes/stats
      ...
      "script_cache" : {
        "sum" : {
          "compilations" : 587,
          "cache_evictions" : 0,
          "compilation_limit_triggered" : 0
        },
```