### PR TITLE
[production] Use 7.11.0-SNAPSHOT as testing stack

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -177,5 +177,5 @@ func TestIntegration() error {
 	if err != nil {
 		return err
 	}
-	return sh.RunV("go", "test", "testing/main_integration_test.go", "-v", "-tags=integration", "2>&1", "|", "go-junit-report", ">", "junit-report.xml")
+	return sh.RunV("go", "test", "testing/main_integration_test.go", "-v", "-tags=integration", "-test.timeout", "30m", "2>&1", "|", "go-junit-report", ">", "junit-report.xml")
 }

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.11.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -24,7 +24,7 @@ services:
     - "script.context.template.cache_max_size=2000"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.11.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -132,7 +132,7 @@ type Package struct {
 
 func getPackages(t *testing.T) ([]string, error) {
 	// The kibana.version must be in sync with the stack version used in snapshot.yml
-	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=7.10.0")
+	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=7.11.0")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Follow-up on https://github.com/elastic/package-storage/pull/710 for production branch.