### PR TITLE
ci: force use bash, param typo

### DIFF
--- a/.ci/release.groovy
+++ b/.ci/release.groovy
@@ -110,7 +110,7 @@ def installKubectl(){
 }
 
 def installGcloud(){
-  sh(lable: 'Install gcloud', script: '''
+  sh(label: 'Install gcloud', script: '''#!/bin/bash
     set -eo pipefail
     ARCH=$(uname|tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
* Force to use bash, it is using sh or dash by default
```
11:58:04  /var/lib/jenkins/workspace/Ingest-manager/release-distribution@tmp/durable-5637b8b7/script.sh: 2: set: Illegal option -o pipefail
```
* Typo on parameter