### PR TITLE
[snapshot] Disable package validation in runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@
 FROM docker.elastic.co/package-registry/distribution:production AS production
 FROM docker.elastic.co/package-registry/distribution:staging AS staging
 
-FROM docker.elastic.co/package-registry/package-registry:v0.15.0
-LABEL package-registry=v0.15.0
+FROM docker.elastic.co/package-registry/package-registry:v0.16.0
+LABEL package-registry=v0.16.0
 
 COPY --from=production /packages/production /packages/production
 COPY --from=staging /packages/staging /packages/staging
@@ -18,3 +18,6 @@ WORKDIR /package-registry
 
 # Sanity check on the packages. If packages are not valid, container does not even build.
 RUN ./package-registry -dry-run
+
+# Override CMD to disable package validation (already done).
+CMD ["--address=0.0.0.0:8080", "-disable-package-validation"]


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/653

This PR disables package validation in runtime as it has already been performed in the build stage.  