### PR TITLE
[production] Disable package validation in runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Here the version of the registry is specified this storage branch uses.
 # It should always be a specific version to make sure builds are reproducible.
-ARG PACKAGE_REGISTRY=v0.15.0
+ARG PACKAGE_REGISTRY=v0.16.0
 FROM docker.elastic.co/package-registry/package-registry:${PACKAGE_REGISTRY}
 
 LABEL package-registry=${PACKAGE_REGISTRY}
@@ -11,3 +11,6 @@ COPY packages /packages/production
 
 # Sanity check on the packages. If packages are not valid, container does not even build.
 RUN ./package-registry -dry-run
+
+# Override CMD to disable package validation (already done).
+CMD ["--address=0.0.0.0:8080", "-disable-package-validation"]


### PR DESCRIPTION
Issue: https://github.com/elastic/package-registry/issues/653

This PR disables package validation in runtime as it has already been performed in the build stage.  