### PR TITLE
Apache: set Kibana migration version to 7.9.3

### DIFF
--- a/packages/apache/0.3.0/kibana/dashboard/apache-Logs-Apache-Dashboard.json
+++ b/packages/apache/0.3.0/kibana/dashboard/apache-Logs-Apache-Dashboard.json
@@ -13,7 +13,7 @@
   },
   "id": "apache-Logs-Apache-Dashboard",
   "migrationVersion": {
-    "dashboard": "7.11.0"
+    "dashboard": "7.9.3"
   },
   "references": [
     {

--- a/packages/apache/0.3.0/kibana/dashboard/apache-Metrics-Apache-HTTPD-server-status.json
+++ b/packages/apache/0.3.0/kibana/dashboard/apache-Metrics-Apache-HTTPD-server-status.json
@@ -13,7 +13,7 @@
   },
   "id": "apache-Metrics-Apache-HTTPD-server-status",
   "migrationVersion": {
-    "dashboard": "7.11.0"
+    "dashboard": "7.9.3"
   },
   "references": [
     {


### PR DESCRIPTION
This PR corrects the Kibana migration version to 7.9.3, so the package can be installed in 7.10.2. 