### PR TITLE
minor enhancement to add context to slack message

### DIFF
--- a/.ci/release.groovy
+++ b/.ci/release.groovy
@@ -71,10 +71,10 @@ pipeline {
   }
   post {
     success {
-      slackMessage(statusMessage: "${params.environment} Deployed success", color: 'good')
+      slackMessage(statusMessage: "${params.environment} package storage cluster deployed successfully", color: 'good')
     }
     failure {
-      slackMessage(statusMessage: "${params.environment} Deployed failure", color: 'warning')
+      slackMessage(statusMessage: "${params.environment} package storage cluster deployment failed!", color: 'warning')
     }
   }
 }


### PR DESCRIPTION
I personally live in several slack channels and seek to disambiguate the commonly used terms 'snapshot' and 'staging' and 'production' as often as I can.  So, I'm proposing a slight increase in context in the slack string for casual viewers to know more about what failed or succeeded. 