### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Here's how these branches relate to repositories and other aspects of packages.
 | How to add a package      | Commit to elastic/integrations* | [`elastic-package promote`](https://github.com/elastic/elastic-package#elastic-package-promote) | [`elastic-package promote`](https://github.com/elastic/elastic-package#elastic-package-promote) |
 | Allow version overwrite?| yes**                        | if needed                  | no                        |
 | Allow version removal?  | yes                         | special exceptions only    | only version increments   |
-| Stack Ver vs Storage Ver| [master branch](https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts#L25) | none set to staging | all non-master branches*** |
+| Stack Ver vs Storage Ver| [master branch](https://github.com/elastic/kibana/blob/master/x-pack/plugins/fleet/server/services/epm/registry/registry_url.ts#L25) | all `-SNAPSHOT` Kibana versions | all shipped or BC versions*** |
 | Registry Version        | Fixed dev or latest stable release | Stable release      | Stable release            |
 | Branch                  | snapshot                    | staging                    | production                |
 | Packages                | snapshot+staging+prod       | staging+production         | production                |
@@ -26,8 +26,8 @@ Here's how these branches relate to repositories and other aspects of packages.
 
 ** removing packages can cause short-term dev problems when a package is in use and then is deleted, some manual maintenance is expected and this does not reflect user experience in production.
 
-*** for example, during the development of 8.0 as master, all 7.x branches (including both snapshot + formal build candidates) will use the production registry by default.  To update this in self managed Kibana usage you can set the below, for example, in the kibana/config/kibana.yml file as a start up option: 
-xpack.fleet.registryUrl: "htttp://epr-staging.elastic.co/"
+*** for example, during the development of 8.0 as master, all 7.x -SNAPSHOT stack versions (including cloud deploys) will use the `staging` repo to facilitate testing prior to package release, while the formal build candidates and shipped stack versions of Kibana are coded to use the `production` registry.  To update the package storage branch used in a self managed Kibana deploy you can set the below, for example, in the kibana/config/kibana.yml file: 
+xpack.fleet.registryUrl: "htttp://epr-snapshot.elastic.co/"
 
 # Update Package Registry for a distribution
 


### PR DESCRIPTION
Due to the support enabled in https://github.com/elastic/kibana/pull/90327 we are now able to update the readme again, and the testing should now be easier for package development!  

Changes are intending to indicate that 'master' branch will use `snapshot` package storage, but all -SNAPSHOT Kibana stack deploys will use `staging`, while the shipped / BC deploys will use `production' EPR storage base.

Is this clear enough?  Open to more changes.