### PR TITLE
ci: use latest ubuntu workers

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'ubuntu && immutable' }
+  agent { label 'ubuntu-20 && immutable' }
   environment {
     BASE_DIR="src/github.com/elastic/package-storage"
     DOCKER_REGISTRY = 'docker.elastic.co'

--- a/.ci/release.groovy
+++ b/.ci/release.groovy
@@ -18,7 +18,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'ubuntu-20 && immutable' }
   environment {
     REPO = "package-storage"
     NOTIFY_TO = credentials('notify-to')


### PR DESCRIPTION
change to use ubuntu 20.04 workers, the beats CI uses old versions of Linux that do not have all the tools we need here.