### PR TITLE
[snapshot] Update "fleet_server" integration to version 0.1.6

### DIFF
--- a/packages/fleet_server/0.1.6/changelog.yml
+++ b/packages/fleet_server/0.1.6/changelog.yml
@@ -1,0 +1,6 @@
+# newer versions go on top
+- version: "0.1.0"
+  changes:
+    - description: initial release
+      type: enhancement # can be one of: enhancement, bugfix, breaking-change
+      link: https://github.com/elastic/integrations/pull/544

--- a/packages/fleet_server/0.1.6/docs/README.md
+++ b/packages/fleet_server/0.1.6/docs/README.md
@@ -1,0 +1,1 @@
+# Fleet Server package

--- a/packages/fleet_server/0.1.6/elasticsearch/ilm_policy/.fleet-actions-results.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/ilm_policy/.fleet-actions-results.json
@@ -1,0 +1,23 @@
+{
+    "policy": {
+        "phases": {
+            "hot": {
+                "min_age": "0ms",
+                "actions": {
+                    "rollover": {
+                        "max_size": "300gb",
+                        "max_age": "30d"
+                    }
+                }
+            },
+            "delete": {
+                "min_age": "90d",
+                "actions": {
+                    "delete": {
+                        "delete_searchable_snapshot": true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-actions-results.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-actions-results.json
@@ -1,0 +1,51 @@
+{
+    "index_patterns": [
+        ".fleet-actions-results"
+    ],
+    "data_stream": {},
+    "template": {
+        "settings": {
+            "index.lifecycle.name": ".fleet-actions-results-ilm-policy"
+        },
+        "mappings": {
+            "dynamic": false,
+            "properties": {
+                "action_id": {
+                    "type": "keyword"
+                },
+                "agent_id": {
+                    "type": "keyword"
+                },
+                "action_data": {
+                    "enabled": false,
+                    "type": "object"
+                },
+                "data": {
+                    "enabled": false,
+                    "type": "object"
+                },
+                "error": {
+                    "type": "text",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword",
+                            "ignore_above": 256
+                        }
+                    }
+                },
+                "@timestamp": {
+                    "type": "date"
+                },
+                "started_at": {
+                    "type": "date"
+                },
+                "completed_at": {
+                    "type": "date"
+                }
+            }
+        }
+    },
+    "composed_of": [],
+    "priority": 200,
+    "version": 1
+}

--- a/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-actions.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-actions.json
@@ -1,0 +1,38 @@
+{
+    "index_patterns": [
+        ".fleet-actions"
+    ],
+    "template": {
+        "settings": {},
+        "mappings": {
+            "dynamic": false,
+            "properties": {
+                "action_id": {
+                    "type": "keyword"
+                },
+                "agents": {
+                    "type": "keyword"
+                },
+                "data": {
+                    "enabled": false,
+                    "type": "object"
+                },
+                "expiration": {
+                    "type": "date"
+                },
+                "input_type": {
+                    "type": "keyword"
+                },
+                "@timestamp": {
+                    "type": "date"
+                },
+                "type": {
+                    "type": "keyword"
+                }
+            }
+        }
+    },
+    "composed_of": [],
+    "priority": 200,
+    "version": 1
+}

--- a/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-agents.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-agents.json
@@ -1,0 +1,228 @@
+{
+    "index_patterns": [
+        ".fleet-agents"
+    ],
+    "template": {
+        "settings": {},
+        "mappings": {
+            "dynamic": false,
+            "properties": {
+                "access_api_key_id": {
+                    "type": "keyword"
+                },
+                "action_seq_no": {
+                    "type": "integer"
+                },
+                "active": {
+                    "type": "boolean"
+                },
+                "agent": {
+                    "properties": {
+                        "id": {
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "default_api_key": {
+                    "type": "keyword"
+                },
+                "default_api_key_id": {
+                    "type": "keyword"
+                },
+                "enrolled_at": {
+                    "type": "date"
+                },
+                "last_checkin": {
+                    "type": "date"
+                },
+                "last_checkin_status": {
+                    "type": "keyword"
+                },
+                "last_updated": {
+                    "type": "date"
+                },
+                "local_metadata": {
+                    "properties": {
+                        "elastic": {
+                            "properties": {
+                                "agent": {
+                                    "properties": {
+                                        "build": {
+                                            "properties": {
+                                                "original": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 256
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "id": {
+                                            "type": "keyword"
+                                        },
+                                        "log_level": {
+                                            "type": "keyword"
+                                        },
+                                        "snapshot": {
+                                            "type": "boolean"
+                                        },
+                                        "upgradeable": {
+                                            "type": "boolean"
+                                        },
+                                        "version": {
+                                            "type": "text",
+                                            "fields": {
+                                                "keyword": {
+                                                    "type": "keyword",
+                                                    "ignore_above": 16
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "host": {
+                            "properties": {
+                                "architecture": {
+                                    "type": "keyword"
+                                },
+                                "hostname": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 256
+                                        }
+                                    }
+                                },
+                                "id": {
+                                    "type": "keyword"
+                                },
+                                "ip": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 64
+                                        }
+                                    }
+                                },
+                                "mac": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 17
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 256
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "os": {
+                            "properties": {
+                                "family": {
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 128
+                                        }
+                                    }
+                                },
+                                "kernel": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 128
+                                        }
+                                    }
+                                },
+                                "name": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 256
+                                        }
+                                    }
+                                },
+                                "platform": {
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 32
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "packages": {
+                    "type": "keyword"
+                },
+                "policy_coordinator_idx": {
+                    "type": "integer"
+                },
+                "policy_id": {
+                    "type": "keyword"
+                },
+                "policy_revision_idx": {
+                    "type": "integer"
+                },
+                "shared_id": {
+                    "type": "keyword"
+                },
+                "type": {
+                    "type": "keyword"
+                },
+                "unenrolled_at": {
+                    "type": "date"
+                },
+                "unenrollment_started_at": {
+                    "type": "date"
+                },
+                "updated_at": {
+                    "type": "date"
+                },
+                "upgrade_started_at": {
+                    "type": "date"
+                },
+                "upgraded_at": {
+                    "type": "date"
+                },
+                "user_provided_metadata": {
+                    "type": "object",
+                    "enabled": false
+                }
+            }
+        }
+    },
+    "composed_of": [],
+    "priority": 200,
+    "version": 1
+}

--- a/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-enrollment-api-keys.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-enrollment-api-keys.json
@@ -1,0 +1,40 @@
+{
+    "index_patterns": [
+        ".fleet-enrollment-api-keys"
+    ],
+    "template": {
+        "settings": {},
+        "mappings": {
+            "dynamic": false,
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                },
+                "api_key": {
+                    "type": "keyword"
+                },
+                "api_key_id": {
+                    "type": "keyword"
+                },
+                "created_at": {
+                    "type": "date"
+                },
+                "expire_at": {
+                    "type": "date"
+                },
+                "name": {
+                    "type": "keyword"
+                },
+                "policy_id": {
+                    "type": "keyword"
+                },
+                "updated_at": {
+                    "type": "date"
+                }
+            }
+        }
+    },
+    "composed_of": [],
+    "priority": 200,
+    "version": 1
+}

--- a/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-policies-leader.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-policies-leader.json
@@ -1,0 +1,29 @@
+{
+    "index_patterns": [
+        ".fleet-policies-leader"
+    ],
+    "template": {
+        "settings": {},
+        "mappings": {
+            "dynamic": false,
+            "properties": {
+                "server": {
+                    "properties": {
+                        "id": {
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "@timestamp": {
+                    "type": "date"
+                }
+            }
+        }
+    },
+    "composed_of": [],
+    "priority": 200,
+    "version": 1
+}

--- a/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-policies.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-policies.json
@@ -1,0 +1,35 @@
+{
+    "index_patterns": [
+        ".fleet-policies"
+    ],
+    "template": {
+        "settings": {},
+        "mappings": {
+            "dynamic": false,
+            "properties": {
+                "coordinator_idx": {
+                    "type": "integer"
+                },
+                "data": {
+                    "enabled": false,
+                    "type": "object"
+                },
+                "default_fleet_server": {
+                    "type": "boolean"
+                },
+                "policy_id": {
+                    "type": "keyword"
+                },
+                "revision_idx": {
+                    "type": "integer"
+                },
+                "@timestamp": {
+                    "type": "date"
+                }
+            }
+        }
+    },
+    "composed_of": [],
+    "priority": 200,
+    "version": 1
+}

--- a/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-servers.json
+++ b/packages/fleet_server/0.1.6/elasticsearch/index_template/.fleet-servers.json
@@ -1,0 +1,55 @@
+{
+    "index_patterns": [
+        ".fleet-servers"
+    ],
+    "template": {
+        "settings": {},
+        "mappings": {
+            "dynamic": false,
+            "properties": {
+                "agent": {
+                    "properties": {
+                        "id": {
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "architecture": {
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "type": "keyword"
+                        },
+                        "ip": {
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "server": {
+                    "properties": {
+                        "id": {
+                            "type": "keyword"
+                        },
+                        "version": {
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "@timestamp": {
+                    "type": "date"
+                }
+            }
+        }
+    },
+    "composed_of": [],
+    "priority": 200,
+    "version": 1
+}

--- a/packages/fleet_server/0.1.6/manifest.yml
+++ b/packages/fleet_server/0.1.6/manifest.yml
@@ -1,6 +1,6 @@
 name: fleet_server
 title: Fleet Server
-version: 0.1.5
+version: 0.1.6
 release: experimental
 description: Fleet Server Integration
 type: integration
@@ -8,7 +8,7 @@ format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: "^7.11.0"
+  kibana.version: "^7.12.0"
 owner:
   github: elastic/ingest-management
 #icons:

--- a/packages/fleet_server/0.1.6/manifest.yml
+++ b/packages/fleet_server/0.1.6/manifest.yml
@@ -1,0 +1,44 @@
+name: fleet_server
+title: Fleet Server
+version: 0.1.5
+release: experimental
+description: Fleet Server Integration
+type: integration
+format_version: 1.0.0
+license: basic
+categories: ["elastic_stack"]
+conditions:
+  kibana.version: "^7.11.0"
+owner:
+  github: elastic/ingest-management
+#icons:
+#  - src: /img/logo-fleet-server.svg
+#    title: Fleet Server
+#    size: 216x216
+#    type: image/svg+xml
+policy_templates:
+  - name: fleet_server
+    title: Fleet Server
+    description: Fleet Server setup
+    inputs:
+      - type: fleet-server
+        vars:
+          - name: host
+            type: text
+            title: Host
+            multi: true
+            required: true
+            show_user: true
+            default:
+              - 0.0.0.0
+          - name: port
+            type: text
+            title: Port
+            required: true
+            show_user: true
+            default:
+              - 8220
+        title: "Fleet Server"
+        description: "Fleet Server Configuration"
+
+# TODO: Make this package hidden?


### PR DESCRIPTION
This PR updates `fleet_server` integration to version 0.1.6.

Changes: https://github.com/elastic/package-storage/commit/c9d3a816a01f570f30a8d945dc5334552b2ccda4