### PR TITLE
ci: workaround to grab the user in a corner case

### DIFF
--- a/.ci/release.groovy
+++ b/.ci/release.groovy
@@ -46,6 +46,11 @@ pipeline {
     choice(choices: ['none', 'snapshot', 'staging', 'prod'], description: 'Environment to Rollout.', name: 'environment')
   }
   stages {
+    stage('Init'){
+      steps{
+        echo "User: ${env?.BUILD_CAUSE_USER ? env.BUILD_CAUSE_USER : 'Unknown'}"
+      }
+    }
     stage('Rollout') {
       when {
         expression {


### PR DESCRIPTION
When the parameter `environment` has the value `none` on, this skips all stages. Seems like if you do not run any stage the variable `BUILD_CAUSE_USER` is not set so we can not put the user in the message