### PR TITLE
[staging] Check if _* folders exist (#1090)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,6 +47,11 @@ pipeline {
     stage('Lint') {
       steps {
         cleanup()
+        dir("${BASE_DIR}"){
+          whenTrue(isGitRegionMatch(patterns: [".*/_.*"])) {
+            error('_dev in packages are intended to exist only for development purposes.')
+          }
+        }
         withMageEnv(){
           dir("${BASE_DIR}"){
             sh(label: 'Checks formatting / linting',script: 'mage -debug check')


### PR DESCRIPTION
This PR will cause CI on the `staging` branch to fail if folders starting with `_` are found. Such folders are expected in packages only for development purposes; they should never make it to the package registry (and therefore package storage).

Related: https://github.com/elastic/package-storage/issues/925