### PR TITLE
[snapshot] Bump up Go dependency on package-registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/package-storage
 go 1.12
 
 require (
-	github.com/elastic/package-registry v0.17.0
+	github.com/elastic/package-registry v0.18.0
 	github.com/magefile/mage v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6 h1:Ehbr7du4rSSEypR8zePr0XRbMhO4PJgcHC9f8fDbgAg=
 github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6/go.mod h1:iaiY0NBIYeasNgycLyTvhJftQlQEUO2hpF+FX0JKxzo=
-github.com/elastic/package-registry v0.17.0 h1:Gh7u3TlHA3GJh+C/OZ8Pf4EUrFxcCXMAe2kUCjAiYgQ=
-github.com/elastic/package-registry v0.17.0/go.mod h1:fMVt9ozLSPAIgYTDgV23IZrSoDKZma7VKpA4uSkfPts=
+github.com/elastic/package-registry v0.18.0 h1:qitudBcRFJn7Ij3YdpBPAC1gcEfAwFQuuioO8GRjeps=
+github.com/elastic/package-registry v0.18.0/go.mod h1:fMVt9ozLSPAIgYTDgV23IZrSoDKZma7VKpA4uSkfPts=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=

--- a/vendor/github.com/elastic/package-registry/util/data_stream.go
+++ b/vendor/github.com/elastic/package-registry/util/data_stream.go
@@ -29,9 +29,10 @@ const (
 )
 
 var validTypes = map[string]string{
-	"logs":    "Logs",
-	"metrics": "Metrics",
-	"traces":  "Traces",
+	"logs":       "Logs",
+	"metrics":    "Metrics",
+	"synthetics": "Synthetics",
+	"traces":     "Traces",
 }
 
 type DataStream struct {

--- a/vendor/github.com/elastic/package-registry/util/package.go
+++ b/vendor/github.com/elastic/package-registry/util/package.go
@@ -109,7 +109,8 @@ type Image struct {
 	// Src is relative inside the package
 	Src string `config:"src" json:"src" validate:"required"`
 	// Path is the absolute path in the url
-	Path  string `config:"path" json:"path"`
+	// TODO: remove yaml struct tag once mage ImportBeats is removed from elastic/integrations repo.
+	Path  string `config:"path" json:"path" yaml:"path,omitempty"`
 	Title string `config:"title" json:"title,omitempty"`
 	Size  string `config:"size" json:"size,omitempty"`
 	Type  string `config:"type" json:"type,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/davecgh/go-spew/spew
 github.com/elastic/go-ucfg
 github.com/elastic/go-ucfg/parse
 github.com/elastic/go-ucfg/yaml
-# github.com/elastic/package-registry v0.17.0
+# github.com/elastic/package-registry v0.18.0
 github.com/elastic/package-registry/util
 # github.com/magefile/mage v1.9.0
 github.com/magefile/mage/mg


### PR DESCRIPTION
This PR bumps up Go dependency on package-registry to v0.18.0.