### PR TITLE
[snapshot] Use 7.13.0-SNAPSHOT as testing stack

### DIFF
--- a/testing/environments/kibana.config.yml
+++ b/testing/environments/kibana.config.yml
@@ -10,6 +10,7 @@ xpack.fleet.enabled: true
 xpack.fleet.registryUrl: "http://package-registry:8080"
 xpack.fleet.agents.enabled: true
 xpack.fleet.agents.elasticsearch.host: "http://elasticsearch:9200"
+xpack.fleet.agents.fleet_server.hosts: ["http://fleet-server:8220"]
 xpack.fleet.agents.kibana.host: "http://kibana:5601"
 xpack.fleet.agents.tlsCheckDisabled: true
 

--- a/testing/environments/local.yml
+++ b/testing/environments/local.yml
@@ -15,6 +15,10 @@ services:
     ports:
       - "127.0.0.1:9200:9200"
 
+  fleet-server:
+    ports:
+      - "127.0.0.1:8220:8220"
+
   package-registry:
     ports:
       - "127.0.0.1:8080:8080"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -37,6 +37,25 @@ services:
     volumes:
       - ./kibana.config.yml:/usr/share/kibana/config/kibana.yml
 
+  fleet-server:
+    image: docker.elastic.co/beats/elastic-agent:7.13.0-SNAPSHOT
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    healthcheck:
+      test: "curl -f http://127.0.0.1:8220/api/status | grep HEALTHY 2>&1 >/dev/null"
+      retries: 12
+      interval: 5s
+    hostname: docker-fleet-server
+    environment:
+      - "FLEET_SERVER_ENABLE=1"
+      - "FLEET_SERVER_INSECURE_HTTP=1"
+      - "KIBANA_FLEET_SETUP=1"
+      - "KIBANA_FLEET_HOST=http://kibana:5601"
+      - "FLEET_SERVER_HOST=0.0.0.0"
+
   package-registry:
     build: ../../
     healthcheck:

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.11.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.0-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9200/"]
       retries: 300
@@ -24,7 +24,7 @@ services:
     - "script.context.template.cache_max_size=2000"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.11.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.13.0-SNAPSHOT
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -112,7 +112,7 @@ type Package struct {
 
 func getPackages(t *testing.T) ([]string, error) {
 	// The kibana.version must be in sync with the stack version used in snapshot.yml
-	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=7.11.0")
+	resp, err := http.Get("http://localhost:8080/search?experimental=true&kibana.version=7.13.0")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -61,7 +61,7 @@ func TestSetup(t *testing.T) {
 	}
 
 	// Run setup in fleet against registry to see if no errors are returned
-	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/fleet/setup", nil)
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:8220/api/fleet/setup", nil)
 	require.NoError(t, err)
 
 	req.Header.Add("kbn-xsrf", "ingest_manager")
@@ -90,7 +90,7 @@ func TestSetup(t *testing.T) {
 }
 
 func installPackage(t *testing.T, p string) {
-	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/fleet/epm/packages/"+p, nil)
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:8220/api/fleet/epm/packages/"+p, nil)
 	require.NoError(t, err)
 
 	req.Header.Add("kbn-xsrf", "ingest_manager")

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -90,7 +90,7 @@ func TestSetup(t *testing.T) {
 }
 
 func installPackage(t *testing.T, p string) {
-	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:8220/api/fleet/epm/packages/"+p, nil)
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/fleet/epm/packages/"+p, nil)
 	require.NoError(t, err)
 
 	req.Header.Add("kbn-xsrf", "ingest_manager")

--- a/testing/main_integration_test.go
+++ b/testing/main_integration_test.go
@@ -61,7 +61,7 @@ func TestSetup(t *testing.T) {
 	}
 
 	// Run setup in fleet against registry to see if no errors are returned
-	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:8220/api/fleet/setup", nil)
+	req, err := http.NewRequest("POST", "http://elastic:changeme@localhost:5601/api/fleet/setup", nil)
 	require.NoError(t, err)
 
 	req.Header.Add("kbn-xsrf", "ingest_manager")


### PR DESCRIPTION
This PR updates the Elastic Stack used for testing PRs to this repository's `snapshot` branch to 7.13.0-SNAPSHOT.

Related: #1203