### PR TITLE
Update warning message for package storage to flag it beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Source: [Fleet overview](https://www.elastic.co/guide/en/fleet/7.13/fleet-overvi
 
 ## Host own Elastic Package Registry
 
-_This procedure is not officially supported._
+_This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features._
 
 If routing traffic through a proxy server is not an option, you need to try the following approach - Package Storage instance must be deployed and hosted on-site as
 Docker container. Package Storage is a special distribution of the Package Registry which already includes packages.


### PR DESCRIPTION
Adding this change to align this README with the Integrations Developer Guide. (https://github.com/elastic/observability-docs/pull/1072)