### PR TITLE
[CI] use obltGitHubComments

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger("${obltGitHubComments()}")
   }
   parameters {
     booleanParam(name: 'run_all_stages', defaultValue: false, description: 'Force to run all stages.')


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/elastic/apm-pipeline-library/blob/master/vars/obltGitHubComments.txt

## Why is it important?

Avoid hardcoded strings and easy to normalise the GitHub comments in all the oblt projects