### PR TITLE
apm: Add error_log.message field

### DIFF
--- a/packages/apm/7.16.0/data_stream/error_logs/fields/ecs.yml
+++ b/packages/apm/7.16.0/data_stream/error_logs/fields/ecs.yml
@@ -152,6 +152,12 @@
   dynamic: true
   name: labels
   type: object
+- description: |-
+    For log events the message field contains the log message, optimized for viewing in a log viewer.
+    For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.
+    If multiple messages exist, they can be combined into one message.
+  name: message
+  type: match_only_text
 - description: Hostname of the observer.
   name: observer.hostname
   type: keyword

--- a/packages/apm/7.16.0/docs/README.md
+++ b/packages/apm/7.16.0/docs/README.md
@@ -511,6 +511,7 @@ Application errors are written to `logs-apm.error.*` data stream.
 | kubernetes.pod.name | Kubernetes pod name | keyword |
 | kubernetes.pod.uid | Kubernetes Pod UID | keyword |
 | labels | A flat mapping of user-defined labels with string, boolean or number values. | object |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | network.carrier.icc | ISO country code, eg. US | keyword |
 | network.carrier.mcc | Mobile country code | keyword |
 | network.carrier.mnc | Mobile network code | keyword |


### PR DESCRIPTION
## Description
Adds the missing "message" field for the error_log datastream.

## Related issues

elastic/apm-server#6450