### PR TITLE
Package registry 1.7.0 in the production registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Here the version of the registry is specified this storage branch uses.
 # It should always be a specific version to make sure builds are reproducible.
-ARG PACKAGE_REGISTRY=v1.6.0
+ARG PACKAGE_REGISTRY=v1.7.0
 
 FROM docker.elastic.co/package-registry/package-registry:${PACKAGE_REGISTRY}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/elastic/package-storage
 go 1.17
 
 require (
-	github.com/elastic/package-registry v1.6.0
+	github.com/elastic/package-registry v1.7.0
 	github.com/magefile/mage v1.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6/go.mod h1:iaiY0N
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
 github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQEGa3c814Ss=
-github.com/elastic/package-registry v1.6.0 h1:Dc9MhHqLVpUXMUyMA5SUYOIP9weqK1PfFp6uWpqyknw=
-github.com/elastic/package-registry v1.6.0/go.mod h1:Urs6TCWJUI57BAGmSWUP8QTa5oxybaV2WB6cvfkBcT8=
+github.com/elastic/package-registry v1.7.0 h1:118vaUcVHcFNq7G0WK7kq+IADgj8jq3U4svCT5VQHlw=
+github.com/elastic/package-registry v1.7.0/go.mod h1:Urs6TCWJUI57BAGmSWUP8QTa5oxybaV2WB6cvfkBcT8=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=


### PR DESCRIPTION
Use [package registry 1.7.0](https://github.com/elastic/package-registry/releases/tag/v1.7.0) in the production registry. This version includes the changes for the release labels.

Part of https://github.com/elastic/package-spec/issues/225.