### PR TITLE
ci: move to fleet-ci

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,10 +1,10 @@
-  
+
 ---
 
 ##### GLOBAL METADATA
 
 - meta:
-    cluster: beats-ci
+    cluster: fleet-ci
 
 ##### JOB DEFAULTS
 


### PR DESCRIPTION
## What is the problem this PR solves?

Use `fleet-ci`  to scale horizontally the CI.


## Why

In order to distribute the load and reduce a single point of failure,

## Actions

- [ ] Agree when to merge
- [ ] Create webhook to point to `fleet-ci`