### PR TITLE
Fix: increase CI build timeout

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
     BUILD_ARTIFACTS_PATH = 'build/packages'
   }
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 3, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
This PR adjusts the build timeout that seems to be too short (based on the latest [commit statuses](https://github.com/elastic/package-storage/commits/production)).  