### PR TITLE
Stop using legacy syntax for parametes on triggerRemoteJob

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -249,7 +249,7 @@ def signArtifactsWithElastic() {
       token: TOKEN,
       parameters: [
         gcs_input_path: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
-      ]
+      ],
       useCrumbCache: true,
       useJobInfoCache: true)
   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -247,7 +247,9 @@ def signArtifactsWithElastic() {
     triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
       job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
       token: TOKEN,
-      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+      parameters: [
+        gcs_input_path: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
+      ]
       useCrumbCache: true,
       useJobInfoCache: true)
   }
@@ -270,14 +272,14 @@ def publishToPackageStorage() {
           triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
             job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
             token: TOKEN,
-            parameters: """
-              dry_run=false
-              gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
-              gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
-              legacy_package=true
-              """,
-              useCrumbCache: true,
-              useJobInfoCache: true)
+            parameters: [
+              dry_run: false,
+              gs_package_build_zip_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}",
+              gs_package_signature_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig",
+              legacy_package: true,
+            ],
+            useCrumbCache: true,
+            useJobInfoCache: true)
         }
       }
     }


### PR DESCRIPTION
Fix issue with legacy format to set the parameters on triggerRemoteJob