### PR TITLE
Rename docker image tag to avoid overwriting V2 images

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
       }
       environment {
         DOCKER_IMG_TAG = "${env.DOCKER_IMG}:${env.GIT_BASE_COMMIT}"
-        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG}:${env.BRANCH_NAME}"
+        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG}:${env.BRANCH_NAME}-old"
       }
       steps {
         cleanup()
@@ -139,7 +139,7 @@ pipeline {
       }
       environment {
         DOCKER_IMG_TAG = "${env.DOCKER_IMG_PR}:${env.GIT_BASE_COMMIT}"
-        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG_PR}:${env.BRANCH_NAME}"
+        DOCKER_IMG_TAG_BRANCH = "${env.DOCKER_IMG_PR}:${env.BRANCH_NAME}-old"
       }
       steps {
         cleanup()


### PR DESCRIPTION
This PR rename the tag used for production docker image. The aim of this change is to avoid overwriting the image pushed by Package Storage V2 in case there is any push to those branches.

Other options:
- disable the job: is it needed to do it in all branches? main, snapshot, staging and production?
- use suffix `-v1` instead of `-old`

Should other branches (snapshot and staging) be updated with the same change? adding a sufix to the docker image.