### PR TITLE
Update Dockerfile to use production-old

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # It should always be a specific version to make sure builds are reproducible.
 ARG PACKAGE_REGISTRY=v1.15.0
 
-FROM docker.elastic.co/package-registry/distribution:production AS production
+FROM docker.elastic.co/package-registry/distribution:production-old AS production
 
 FROM docker.elastic.co/package-registry/package-registry:${PACKAGE_REGISTRY}
 LABEL package-registry=${PACKAGE_REGISTRY}


### PR DESCRIPTION
In order to be able to run these pipelines after the switch to Package Storage V2 Dockerfile must be using production-old as base docker image